### PR TITLE
include OBv3 fields in credential display

### DIFF
--- a/components/CredentialCard/CredentialCard.d.ts
+++ b/components/CredentialCard/CredentialCard.d.ts
@@ -1,7 +1,15 @@
-import type { Credential } from 'types/credential';
-import { VerifiablePresentation } from 'types/presentation';
+import type { VerifiableCredential } from 'types/credential';
 
 export type CredentialCardProps = {
-  credential: Credential,
+  credential: VerifiableCredential,
   wasMulti?: Boolean
+}
+
+export type CredentialDisplayFields = {
+  credentialName: string | undefined,
+  issuedTo: string | undefined,
+  issuanceDate: string | undefined,
+  expirationDate: string | undefined,
+  credentialDescription: string | undefined,
+  criteria: string | undefined,
 }

--- a/components/Issuer/Issuer.tsx
+++ b/components/Issuer/Issuer.tsx
@@ -22,7 +22,7 @@ export const Issuer = ({issuer, header, infoButtonPushed}: IssuerProps ) => {
           <h2 className={styles.header}>{header}</h2>
           <div className={styles.issuer}>
             {issuer.image && (
-              <img src={issuer.image} width={36} height={36} alt={`${issuer.name} logo`} ref={issuerImage} onError={handleonError} />
+              <img src={issuer.image?.id || issuer.image} width={36} height={36} alt={`${issuer.name} logo`} ref={issuerImage} onError={handleonError} />
             )}
             <div className={styles.issuerInformation}>
               <div>{issuer.name}

--- a/types/credential.d.ts
+++ b/types/credential.d.ts
@@ -35,10 +35,22 @@ export type EducationalOperationalCredential = EducationalOperationalCredentialE
   readonly credentialCategory?: string;
 }
 
+export type OpenBadgeAchievement = {
+  readonly achievementType?: string;
+  readonly criteria?: {
+        readonly narrative?: string
+      },
+  readonly description?: string,
+  readonly id?: string,
+  readonly name?: string,
+  readonly type?: string;
+}
+
 type SubjectExtensions = {
   readonly type?: string;
   readonly name?: string;
   readonly hasCredential?: EducationalOperationalCredential; // https://schema.org/hasCredential
+  readonly achievement?: OpenBadgeAchievement
 }
 
 export type Subject = SubjectExtensions & {


### PR DESCRIPTION
I've added a mapping for the credential display that uses OBv3 fields if the credential has type 'OpenBadgeCredential', and otherwise uses the fields that had been used before for the DCC pre-OBv3 VC.