### PR TITLE
added markdown support for criteria verifier plus issue #84

### DIFF
--- a/components/CredentialCard/CredentialCard.tsx
+++ b/components/CredentialCard/CredentialCard.tsx
@@ -22,7 +22,6 @@ export const CredentialCard = ({ credential, wasMulti = false }: CredentialCardP
     setIsOpen(true);
   }
 
-
   return (
     <main aria-labelledby='title'>
       {wasMulti && (


### PR DESCRIPTION
Solution for [Issue #84](https://github.com/digitalcredentials/web-verifier-plus/issues/84) using the react-markdown package to add markdown support to the criteria field in the credential display.

Works with all the common tags I tested. I would need to test with some actual badges to be completely sure that it works as intended.