### PR TITLE
update doc loader to load from web

### DIFF
--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -7,7 +7,7 @@ import { VerifiableCredential, CredentialError, CredentialErrorTypes } from 'typ
 import { securityLoader } from '@digitalcredentials/security-document-loader';
 import { extractCredentialsFrom } from './verifiableObject';
 import { registryCollections } from '@digitalcredentials/issuer-registry-client';
-const documentLoader = securityLoader().build();
+const documentLoader = securityLoader({ fetchRemoteContexts: true }).build()
 const suite = new Ed25519Signature2020();
 const presentationPurpose = new purposes.AssertionProofPurpose();
 


### PR DESCRIPTION
@dmitrizagidulin As discussed, configures security document loader to load from web. This is to fix the problem where the vc-status-list package couldn't access the status list document for a VC because the document loader by default only loads locally.