### PR TITLE
Better error message when json isn't a verifiable credential

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -276,7 +276,7 @@ const Home: NextPage = () => {
               warning
             </span>
             <p className={styles.error}>
-              JSON cannot be parsed
+            The JSON is not a Verifiable Credential or an Open Badge 3.0
             </p>
           </div>
         )}


### PR DESCRIPTION
Updated error message when json isn't a verifiable credential