### PR TITLE
Add rel={'noreferrer'} to fix error

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -354,7 +354,7 @@ const Home: NextPage = () => {
             onClose={() => stopPolling(undefined)}
             title="Request credentials from LCW" >
             <p>
-              <a className={styles.lcwLink} target={'_blank'} href={lcwRequestUrl}><h3>Mobile Link</h3></a>
+              <a className={styles.lcwLink} target={'_blank'} rel={'noreferrer'} href={lcwRequestUrl}><h3>Mobile Link</h3></a>
             </p>
             <div><h5 className={styles.lcwLink}>Open Request in wallet via QR Code:</h5></div>
             <div className={styles.qrCode}>


### PR DESCRIPTION
Fixes error: Error: Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank