### PR TITLE
update verifier core package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-verifier-plus",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-verifier-plus",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "dependencies": {
         "@digitalcredentials/ed25519-signature-2020": "^6.0.0",
         "@digitalcredentials/issuer-registry-client": "^3.0.0",
@@ -14,7 +14,7 @@
         "@digitalcredentials/vc": "^9.0.1",
         "@digitalcredentials/vc-bitstring-status-list": "^1.0.0",
         "@digitalcredentials/vc-status-list": "^9.0.0",
-        "@digitalcredentials/verifier-core": "^1.0.0-beta.2",
+        "@digitalcredentials/verifier-core": "^1.0.0-beta.7",
         "@digitalcredentials/vpqr": "^2.2.1",
         "axios": "^1.7.7",
         "credential-handler-polyfill": "^4.0.0",
@@ -838,9 +838,9 @@
       }
     },
     "node_modules/@digitalcredentials/data-integrity": {
-      "version": "2.6.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/data-integrity/-/data-integrity-2.6.0-beta.1.tgz",
-      "integrity": "sha512-8eoZNw2363PsWakrzbfIpMLIKm0/3iJCIehXoUdJLKgbvezn5pIP33+CQ+1cmysM4Udvt/8RXp5J+JS/teFruw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/data-integrity/-/data-integrity-2.6.0.tgz",
+      "integrity": "sha512-vk8nFmkdQfOf6VvJk2lw6tIdORI8r4rOrxYZvb1pBh/1d+IJ7O6csnXJUmmQA2UJ6dwfxFuFyADORgc2ZYb4iA==",
       "dependencies": {
         "@digitalcredentials/jsonld-signatures": "^12.0.1",
         "base58-universal": "^2.0.0",
@@ -906,12 +906,12 @@
       }
     },
     "node_modules/@digitalcredentials/did-method-web": {
-      "version": "1.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-web/-/did-method-web-1.1.0-beta.1.tgz",
-      "integrity": "sha512-VmtZdUswUgnjV3+eo8J5qXS7brbV3+PXCYQMkZlP2g2AYeaRzME3kVDoGdsVJrvJMBZcp8GdrUtqhcLweaX8DA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-web/-/did-method-web-1.1.0.tgz",
+      "integrity": "sha512-FgsCNGz6Iniy1fR5G8wcT1EMfQzVPJUhz3ei9Ha0aavN3K3dD2XTIKG83vAV3L9tpmtcQhdwcIG+2JaBO1PBYQ==",
       "dependencies": {
         "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/did-method-key": "^3.0.0-beta.1",
+        "@digitalcredentials/did-method-key": "^3.0.0",
         "@digitalcredentials/http-client": "^5.0.4",
         "klona": "^2.0.6"
       },
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@digitalcredentials/did-method-web/node_modules/@digitalcredentials/did-method-key": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0-beta.1.tgz",
-      "integrity": "sha512-BVTCN2McsLJjwh+3X0a//draAn0NQg4xsSYeKbrq+JjGqvMlV+aFTYoi6bFe6dsJK6RhLDxkbgxFgjfk/+UTsg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0.tgz",
+      "integrity": "sha512-Cq75fbUkDed1O3TPFY89xlqq+oCKvBCMjDJz8KIVx75eZCnxhcE9h/a4t9yW0FRnp0LBrV9HDoSPNyN9P6dr1A==",
       "dependencies": {
         "@digitalcredentials/did-io": "^1.0.2",
         "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2"
@@ -946,9 +946,9 @@
       }
     },
     "node_modules/@digitalcredentials/ed25519-multikey": {
-      "version": "1.4.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/ed25519-multikey/-/ed25519-multikey-1.4.0-beta.1.tgz",
-      "integrity": "sha512-km1WnJLi/XfyHpJq2m34RtZBUxwukfaCGHFRqqagcyTPaE3WqIHjEHQeRkd26tHwJ6p1+jMESj9JNODjqwVMhQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/ed25519-multikey/-/ed25519-multikey-1.4.0.tgz",
+      "integrity": "sha512-BXgNEX42a1EwnUantP6Po7yt43BamajrzVIvips6/egcQIFfXFHwl8yBvmPndsNY1Q9HKv/b743Nl5C3HEt8PA==",
       "dependencies": {
         "@noble/ed25519": "^1.6.0",
         "@stablelib/ed25519": "^2.0.2",
@@ -1052,11 +1052,11 @@
       }
     },
     "node_modules/@digitalcredentials/eddsa-rdfc-2022-cryptosuite": {
-      "version": "1.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/eddsa-rdfc-2022-cryptosuite/-/eddsa-rdfc-2022-cryptosuite-1.3.0-beta.1.tgz",
-      "integrity": "sha512-NHOzjnupKbpRuVy8jOzwFt7oWDl77q5K/+LBPQLITcacEJz/qh04NeRB8pGxcRTn6mhNhFRwQxEMm37lMxDsXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/eddsa-rdfc-2022-cryptosuite/-/eddsa-rdfc-2022-cryptosuite-1.3.0.tgz",
+      "integrity": "sha512-tLebsSZGTqGu6VxGjxv8g18NuBmRxew20WgaIxaBoWpLr2cbWDKKkTs40nWWLQPhm/UPC7x4XWkkIWZq33K4eg==",
       "dependencies": {
-        "@digitalcredentials/ed25519-multikey": "^1.4.0-beta.1",
+        "@digitalcredentials/ed25519-multikey": "^1.4.0",
         "@digitalcredentials/jsonld": "^9.0.0",
         "rdf-canonize": "^4.0.1"
       },
@@ -1301,17 +1301,17 @@
       }
     },
     "node_modules/@digitalcredentials/verifier-core": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/verifier-core/-/verifier-core-1.0.0-beta.2.tgz",
-      "integrity": "sha512-c/nqO3QdQnR2sdDLFCScdqziW+4V88Err6yElu4fzPrFb5ndec0dKZsd8p7JSd/99JmyrLo7R+3TDYZyVwCz/w==",
+      "version": "1.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/verifier-core/-/verifier-core-1.0.0-beta.7.tgz",
+      "integrity": "sha512-UuCVtzvYHTgYQs1rq2FjEPUV95OwVrhS+vhc8CxxVvBSw8goEZUzNDbV1Bi/x+VIvyVQX8p9vsBtRwgW9T0muQ==",
       "dependencies": {
-        "@digitalcredentials/data-integrity": "^2.6.0-beta.1",
-        "@digitalcredentials/ed25519-signature-2020": "^7.0.0-beta.1",
-        "@digitalcredentials/eddsa-rdfc-2022-cryptosuite": "^1.3.0-beta.1",
-        "@digitalcredentials/issuer-registry-client": "^3.2.0-beta.1",
+        "@digitalcredentials/data-integrity": "^2.6.0",
+        "@digitalcredentials/ed25519-signature-2020": "^7.0.0",
+        "@digitalcredentials/eddsa-rdfc-2022-cryptosuite": "^1.3.0",
+        "@digitalcredentials/issuer-registry-client": "^3.2.0-beta.5",
         "@digitalcredentials/jsonld-signatures": "^12.0.1",
-        "@digitalcredentials/security-document-loader": "^7.0.0-beta.1",
-        "@digitalcredentials/vc": "^10.0.0-beta.1",
+        "@digitalcredentials/security-document-loader": "^8.0.0",
+        "@digitalcredentials/vc": "^10.0.0",
         "@digitalcredentials/vc-bitstring-status-list": "^1.0.0"
       },
       "engines": {
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/did-method-key": {
-      "version": "3.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0-beta.1.tgz",
-      "integrity": "sha512-BVTCN2McsLJjwh+3X0a//draAn0NQg4xsSYeKbrq+JjGqvMlV+aFTYoi6bFe6dsJK6RhLDxkbgxFgjfk/+UTsg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0.tgz",
+      "integrity": "sha512-Cq75fbUkDed1O3TPFY89xlqq+oCKvBCMjDJz8KIVx75eZCnxhcE9h/a4t9yW0FRnp0LBrV9HDoSPNyN9P6dr1A==",
       "dependencies": {
         "@digitalcredentials/did-io": "^1.0.2",
         "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2"
@@ -1345,12 +1345,12 @@
       }
     },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/ed25519-signature-2020": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/ed25519-signature-2020/-/ed25519-signature-2020-7.0.0-beta.1.tgz",
-      "integrity": "sha512-G0uS9/yLGxY6oAO+WDW5hnL5K3LtUMy1tg/HjOKk2QOSaQU6Fkjlkyaez1Ey7WQYBLzsV8r4bsv0Nx0H0y7aCA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/ed25519-signature-2020/-/ed25519-signature-2020-7.0.0.tgz",
+      "integrity": "sha512-Q0HdBdYKfg6yiPMJ1NlZMbUslSAVVwet/WhA/8emddb7W9lmmAtPJv3f9AuMfLFhY70z29Iedc5KWxqqbkMHbA==",
       "dependencies": {
         "@digitalcredentials/base58-universal": "^1.0.1",
-        "@digitalcredentials/ed25519-multikey": "^1.4.0-beta.1",
+        "@digitalcredentials/ed25519-multikey": "^1.4.0",
         "@digitalcredentials/ed25519-verification-key-2020": "^3.1.1",
         "@digitalcredentials/jsonld-signatures": "^12.0.1",
         "ed25519-signature-2018-context": "^1.1.0",
@@ -1361,34 +1361,36 @@
       }
     },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/issuer-registry-client": {
-      "version": "3.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/issuer-registry-client/-/issuer-registry-client-3.2.0-beta.1.tgz",
-      "integrity": "sha512-F6UZCjwugUdn7zU/IZxL/5jEZuBgywljHa8S02DRg9BCJy9vn3v+fUNL4nxjNwn0dhFFbN1rjUtPZ4gy+7WfHw==",
+      "version": "3.2.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/issuer-registry-client/-/issuer-registry-client-3.2.0-beta.5.tgz",
+      "integrity": "sha512-uwL7xkRpeANAtJ5Cgn6FDcVCjjEA959+HPokHB4IzV/gabnBBN1y8r3uCFwMTF6qCq30pA6+RZAhKsqMCI1SDw==",
       "dependencies": {
-        "@digitalcredentials/http-client": "^5.0.2"
+        "@digitalcredentials/http-client": "^5.0.2",
+        "core-js": "^3.42.0",
+        "jwt-decode": "^4.0.0"
       },
       "engines": {
         "node": ">=18.0"
       }
     },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader": {
-      "version": "7.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/security-document-loader/-/security-document-loader-7.0.0-beta.1.tgz",
-      "integrity": "sha512-AwJ15rvUR5UYHcNpzAgAJZRnNaB0aE5HIJz+OVKT3B1zcPuX3jps6hAxTdW1OqwBfvlkKCrNk05oXE2x3t7cXA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/security-document-loader/-/security-document-loader-8.0.0.tgz",
+      "integrity": "sha512-0rURdip0S/L4aegONkef5yzaGqQ35n7TXE0RhtEJa6scEaZssazaADgg9ApMA47kiGRjCn30yKrds9YULwoltA==",
       "dependencies": {
         "@digitalbazaar/data-integrity-context": "^2.0.0",
         "@digitalbazaar/vc-bitstring-status-list-context": "^1.0.0",
         "@digitalbazaar/vc-status-list-context": "^3.0.1",
-        "@digitalcredentials/credentials-v2-context": "~0.0.1-beta.0",
+        "@digitalcredentials/credentials-v2-context": "^1.0.0",
         "@digitalcredentials/crypto-ld": "^7.0.2",
         "@digitalcredentials/dcc-context": "^1.0.0",
         "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/did-method-key": "^3.0.0-beta.1",
-        "@digitalcredentials/did-method-web": "^1.1.0-beta.1",
-        "@digitalcredentials/ed25519-multikey": "^1.4.0-beta.1",
+        "@digitalcredentials/did-method-key": "^3.0.0",
+        "@digitalcredentials/did-method-web": "^1.1.0",
+        "@digitalcredentials/ed25519-multikey": "^1.4.0",
         "@digitalcredentials/ed25519-verification-key-2020": "^3.2.2",
         "@digitalcredentials/http-client": "^5.0.1",
-        "@digitalcredentials/open-badges-context": "^2.1.0",
+        "@digitalcredentials/open-badges-context": "^3.0.0",
         "@digitalcredentials/x25519-key-agreement-key-2020": "^3.0.0",
         "credentials-context": "^2.0.0",
         "did-context": "^3.1.1",
@@ -1401,10 +1403,23 @@
         "node": ">=16.0"
       }
     },
+    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/credentials-v2-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/credentials-v2-context/-/credentials-v2-context-1.0.0.tgz",
+      "integrity": "sha512-n+zBS+fYlKfvDmt8jdpB6n6p2JRLo6v6A2BGLVmbqzHFvfdQZXS+t489TWipFmi5g3FV12/bDCILUpCrqswDvg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/open-badges-context": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/open-badges-context/-/open-badges-context-3.0.0.tgz",
+      "integrity": "sha512-pyXirpq29gy+NIaTBozDEm7nk1Oh8Yqie2WR0JuIqRX0ePCbiFeMv2uPEP3TXzyh1Jz++28fD+qjNojlhUmiIw=="
+    },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/vc": {
-      "version": "10.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/vc/-/vc-10.0.0-beta.1.tgz",
-      "integrity": "sha512-PrxtME3JGFIasWP1aEb7YgZLEU/INlEagovBd+CqoPatwgdfFwdZCTKTgvKuO+Y12J8W6/A16xbmpGXjh9OViw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/vc/-/vc-10.0.0.tgz",
+      "integrity": "sha512-yHSE2iJy/uhdboa7ybO+emGMiKAlhq4iRXvsteUWSoBtNE20CoBeSKJ1Fh06EhbzlOyLJSBg2s54C9dParehdw==",
       "dependencies": {
         "@digitalcredentials/credentials-v2-context": "^0.0.1-beta.0",
         "@digitalcredentials/jsonld": "^9.0.0",
@@ -3346,9 +3361,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001713",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+      "version": "1.0.30001717",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
+      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
       "funding": [
         {
           "type": "opencollective",
@@ -3472,6 +3487,16 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
+      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -5689,6 +5714,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@digitalcredentials/ed25519-signature-2020": "^6.0.0",
         "@digitalcredentials/issuer-registry-client": "^3.0.0",
-        "@digitalcredentials/security-document-loader": "^6.0.0",
+        "@digitalcredentials/security-document-loader": "^8.0.0",
         "@digitalcredentials/vc": "^9.0.1",
         "@digitalcredentials/vc-bitstring-status-list": "^1.0.0",
         "@digitalcredentials/vc-status-list": "^9.0.0",
@@ -787,18 +787,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@digitalcredentials/bnid": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/bnid/-/bnid-3.0.1.tgz",
-      "integrity": "sha512-okw9d94w09LIDz1ahwW+N5WB/4jhotH0K4+VepooA7scCcv6kyyMMcVPTsEKqxGhY88EiCYoFoL/T4kz6k6JnQ==",
-      "dependencies": {
-        "base-x": "^4.0.0",
-        "react-native-securerandom": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@digitalcredentials/cborld": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@digitalcredentials/cborld/-/cborld-4.3.4.tgz",
@@ -879,16 +867,15 @@
       }
     },
     "node_modules/@digitalcredentials/did-method-key": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-2.0.3.tgz",
-      "integrity": "sha512-b31TOIKJm+qcay7m9kxV6TDNyJwdb/XZIS/OjHarONlXGB3k0M38NXmbRDI95FTmy3GhYCFSJ3VEikqNKTXU2A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0.tgz",
+      "integrity": "sha512-Cq75fbUkDed1O3TPFY89xlqq+oCKvBCMjDJz8KIVx75eZCnxhcE9h/a4t9yW0FRnp0LBrV9HDoSPNyN9P6dr1A==",
       "dependencies": {
         "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/ed25519-verification-key-2020": "^3.1.2",
         "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/@digitalcredentials/did-method-key/node_modules/@digitalcredentials/x25519-key-agreement-key-2020": {
@@ -917,32 +904,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@digitalcredentials/did-method-web/node_modules/@digitalcredentials/did-method-key": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0.tgz",
-      "integrity": "sha512-Cq75fbUkDed1O3TPFY89xlqq+oCKvBCMjDJz8KIVx75eZCnxhcE9h/a4t9yW0FRnp0LBrV9HDoSPNyN9P6dr1A==",
-      "dependencies": {
-        "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@digitalcredentials/did-method-web/node_modules/@digitalcredentials/x25519-key-agreement-key-2020": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/x25519-key-agreement-key-2020/-/x25519-key-agreement-key-2020-2.0.2.tgz",
-      "integrity": "sha512-7Ay5AkGfIEWBRJiHl6PhrpFrjAqCZ/+G4rV6sqTUGK8fBnkxqlJ/XiD7NouUF6uTalVm7mJWJXHuCN5FAuXGsg==",
-      "dependencies": {
-        "@digitalcredentials/base58-universal": "^1.0.0",
-        "crypto-ld": "^6.0.0",
-        "ed2curve": "^0.3.0",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@digitalcredentials/ed25519-multikey": {
@@ -1165,23 +1126,24 @@
       "integrity": "sha512-VK7X5u6OoBFxkyIFplNqUPVbo+8vFSAEoam8tSozpj05KPfcGw41Tp5p9fqMnY38oPfwtZR2yDNSctj/slrE0A=="
     },
     "node_modules/@digitalcredentials/security-document-loader": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/security-document-loader/-/security-document-loader-6.0.1.tgz",
-      "integrity": "sha512-u3NereDzc5Wp7LwAGq4r7pKe1FzoOc4z5vB6a0gFtte/PR0S3qIbymNFy3sscztWeadkbCzfJRE0YmRt6fA8xg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/security-document-loader/-/security-document-loader-8.0.0.tgz",
+      "integrity": "sha512-0rURdip0S/L4aegONkef5yzaGqQ35n7TXE0RhtEJa6scEaZssazaADgg9ApMA47kiGRjCn30yKrds9YULwoltA==",
       "dependencies": {
         "@digitalbazaar/data-integrity-context": "^2.0.0",
         "@digitalbazaar/vc-bitstring-status-list-context": "^1.0.0",
         "@digitalbazaar/vc-status-list-context": "^3.0.1",
-        "@digitalcredentials/credentials-v2-context": "~0.0.1-beta.0",
+        "@digitalcredentials/credentials-v2-context": "^1.0.0",
         "@digitalcredentials/crypto-ld": "^7.0.2",
         "@digitalcredentials/dcc-context": "^1.0.0",
         "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/did-method-key": "^2.0.3",
+        "@digitalcredentials/did-method-key": "^3.0.0",
+        "@digitalcredentials/did-method-web": "^1.1.0",
+        "@digitalcredentials/ed25519-multikey": "^1.4.0",
         "@digitalcredentials/ed25519-verification-key-2020": "^3.2.2",
         "@digitalcredentials/http-client": "^5.0.1",
-        "@digitalcredentials/open-badges-context": "^2.1.0",
+        "@digitalcredentials/open-badges-context": "^3.0.0",
         "@digitalcredentials/x25519-key-agreement-key-2020": "^3.0.0",
-        "@interop/did-web-resolver": "^5.0.0",
         "credentials-context": "^2.0.0",
         "did-context": "^3.1.1",
         "ed25519-signature-2020-context": "^1.1.0",
@@ -1192,6 +1154,19 @@
       "engines": {
         "node": ">=16.0"
       }
+    },
+    "node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/credentials-v2-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/credentials-v2-context/-/credentials-v2-context-1.0.0.tgz",
+      "integrity": "sha512-n+zBS+fYlKfvDmt8jdpB6n6p2JRLo6v6A2BGLVmbqzHFvfdQZXS+t489TWipFmi5g3FV12/bDCILUpCrqswDvg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/open-badges-context": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalcredentials/open-badges-context/-/open-badges-context-3.0.0.tgz",
+      "integrity": "sha512-pyXirpq29gy+NIaTBozDEm7nk1Oh8Yqie2WR0JuIqRX0ePCbiFeMv2uPEP3TXzyh1Jz++28fD+qjNojlhUmiIw=="
     },
     "node_modules/@digitalcredentials/vc": {
       "version": "9.0.1",
@@ -1318,32 +1293,6 @@
         "node": ">=18.0"
       }
     },
-    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/did-method-key": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/did-method-key/-/did-method-key-3.0.0.tgz",
-      "integrity": "sha512-Cq75fbUkDed1O3TPFY89xlqq+oCKvBCMjDJz8KIVx75eZCnxhcE9h/a4t9yW0FRnp0LBrV9HDoSPNyN9P6dr1A==",
-      "dependencies": {
-        "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/x25519-key-agreement-key-2020": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/did-method-key/node_modules/@digitalcredentials/x25519-key-agreement-key-2020": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/x25519-key-agreement-key-2020/-/x25519-key-agreement-key-2020-2.0.2.tgz",
-      "integrity": "sha512-7Ay5AkGfIEWBRJiHl6PhrpFrjAqCZ/+G4rV6sqTUGK8fBnkxqlJ/XiD7NouUF6uTalVm7mJWJXHuCN5FAuXGsg==",
-      "dependencies": {
-        "@digitalcredentials/base58-universal": "^1.0.0",
-        "crypto-ld": "^6.0.0",
-        "ed2curve": "^0.3.0",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/ed25519-signature-2020": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@digitalcredentials/ed25519-signature-2020/-/ed25519-signature-2020-7.0.0.tgz",
@@ -1372,49 +1321,6 @@
       "engines": {
         "node": ">=18.0"
       }
-    },
-    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/security-document-loader/-/security-document-loader-8.0.0.tgz",
-      "integrity": "sha512-0rURdip0S/L4aegONkef5yzaGqQ35n7TXE0RhtEJa6scEaZssazaADgg9ApMA47kiGRjCn30yKrds9YULwoltA==",
-      "dependencies": {
-        "@digitalbazaar/data-integrity-context": "^2.0.0",
-        "@digitalbazaar/vc-bitstring-status-list-context": "^1.0.0",
-        "@digitalbazaar/vc-status-list-context": "^3.0.1",
-        "@digitalcredentials/credentials-v2-context": "^1.0.0",
-        "@digitalcredentials/crypto-ld": "^7.0.2",
-        "@digitalcredentials/dcc-context": "^1.0.0",
-        "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/did-method-key": "^3.0.0",
-        "@digitalcredentials/did-method-web": "^1.1.0",
-        "@digitalcredentials/ed25519-multikey": "^1.4.0",
-        "@digitalcredentials/ed25519-verification-key-2020": "^3.2.2",
-        "@digitalcredentials/http-client": "^5.0.1",
-        "@digitalcredentials/open-badges-context": "^3.0.0",
-        "@digitalcredentials/x25519-key-agreement-key-2020": "^3.0.0",
-        "credentials-context": "^2.0.0",
-        "did-context": "^3.1.1",
-        "ed25519-signature-2020-context": "^1.1.0",
-        "html-entities": "^2.3.3",
-        "jsonld-document-loader": "^1.2.1",
-        "x25519-key-agreement-2020-context": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16.0"
-      }
-    },
-    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/credentials-v2-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/credentials-v2-context/-/credentials-v2-context-1.0.0.tgz",
-      "integrity": "sha512-n+zBS+fYlKfvDmt8jdpB6n6p2JRLo6v6A2BGLVmbqzHFvfdQZXS+t489TWipFmi5g3FV12/bDCILUpCrqswDvg==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/security-document-loader/node_modules/@digitalcredentials/open-badges-context": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@digitalcredentials/open-badges-context/-/open-badges-context-3.0.0.tgz",
-      "integrity": "sha512-pyXirpq29gy+NIaTBozDEm7nk1Oh8Yqie2WR0JuIqRX0ePCbiFeMv2uPEP3TXzyh1Jz++28fD+qjNojlhUmiIw=="
     },
     "node_modules/@digitalcredentials/verifier-core/node_modules/@digitalcredentials/vc": {
       "version": "10.0.0",
@@ -1512,23 +1418,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
-    },
-    "node_modules/@interop/did-web-resolver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@interop/did-web-resolver/-/did-web-resolver-5.0.0.tgz",
-      "integrity": "sha512-Gvv13DtUYFjkSx00ioq4A7dZd8B/0ETOaqYymBgFHvNH7DCBm5v1gyqax/4MBOeSBwf6KTrQWmvqaGYbE9P4Bw==",
-      "dependencies": {
-        "@digitalcredentials/bnid": "^3.0.1",
-        "@digitalcredentials/did-io": "^1.0.2",
-        "@digitalcredentials/http-client": "^5.0.1",
-        "did-context": "^3.1.1",
-        "ed25519-signature-2020-context": "^1.1.0",
-        "whatwg-url": "^14.0.0",
-        "x25519-key-agreement-2020-context": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.2.2",
@@ -3178,11 +3067,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
-    "node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="
     },
     "node_modules/base32-decode": {
       "version": "1.0.0",
@@ -7132,17 +7016,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
-    "node_modules/react-native-securerandom": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-1.0.1.tgz",
-      "integrity": "sha512-ibuDnd3xi17HyD5CkilOXGPFpS9Z1oifjyHFwUl8NMzcQcpruM0ZX8ytr3A4rCeAsaBHjz69r78Xgd6vUswv1Q==",
-      "dependencies": {
-        "base64-js": "*"
-      },
-      "peerDependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/react-qr-reader": {
       "version": "3.0.0-beta-1",
       "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-3.0.0-beta-1.tgz",
@@ -7947,17 +7820,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
-      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -8383,18 +8245,6 @@
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@digitalcredentials/ed25519-signature-2020": "^6.0.0",
     "@digitalcredentials/issuer-registry-client": "^3.0.0",
-    "@digitalcredentials/security-document-loader": "^6.0.0",
+    "@digitalcredentials/security-document-loader": "^8.0.0",
     "@digitalcredentials/vc": "^9.0.1",
     "@digitalcredentials/vc-bitstring-status-list": "^1.0.0",
     "@digitalcredentials/vc-status-list": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@digitalcredentials/vc": "^9.0.1",
     "@digitalcredentials/vc-bitstring-status-list": "^1.0.0",
     "@digitalcredentials/vc-status-list": "^9.0.0",
-    "@digitalcredentials/verifier-core": "^1.0.0-beta.4",
+    "@digitalcredentials/verifier-core": "^1.0.0-beta.7",
     "@digitalcredentials/vpqr": "^2.2.1",
     "axios": "^1.7.7",
     "credential-handler-polyfill": "^4.0.0",


### PR DESCRIPTION
updates @digitalcredentials/verifier-core to 1.0.0-beta.7
to thereby pull in newly updated VC DM 2.0 and OBv3.0.3 contexts